### PR TITLE
[TECH-5675] Display friendly API errors

### DIFF
--- a/assets/js/application/useGetPostSEOData.ts
+++ b/assets/js/application/useGetPostSEOData.ts
@@ -8,7 +8,7 @@ interface RunArgs {
 }
 
 interface OutputSection<TData> {
-  isError: boolean
+  error: unknown
   isLoading: boolean
   data?: TData
   history: History
@@ -170,7 +170,7 @@ export const useGetPostSEOData = ({
 
   return {
     headlines: {
-      isError: headline.isError,
+      error: headline.error,
       isLoading: headline.isLoading,
       ...headlines,
       refresh: (args: RunArgs) => {
@@ -178,7 +178,7 @@ export const useGetPostSEOData = ({
       },
     },
     metaDescriptions: {
-      isError: metaDescriptionsMutation.isError,
+      error: metaDescriptionsMutation.error,
       isLoading: metaDescriptionsMutation.isLoading,
       ...metaDescriptions,
       refresh: (args: RunArgs) => {
@@ -186,7 +186,7 @@ export const useGetPostSEOData = ({
       },
     },
     metaTitles: {
-      isError: metaTitlesMutation.isError,
+      error: metaTitlesMutation.error,
       isLoading: metaTitlesMutation.isLoading,
       ...metaTitles,
       refresh: (args: RunArgs) => {
@@ -195,7 +195,7 @@ export const useGetPostSEOData = ({
     },
     run,
     excerpt: {
-      isError: summary.isError,
+      error: summary.error,
       isLoading: summary.isLoading,
       ...excerpts,
       refresh: (args: RunArgs) => {
@@ -203,7 +203,7 @@ export const useGetPostSEOData = ({
       },
     },
     tags: {
-      isError: tagsMutation.isError,
+      error: tagsMutation.error,
       isLoading: tagsMutation.isLoading,
       ...tags,
       refresh: (args: RunArgs) => {

--- a/assets/js/components/AsyncStateManager/AsyncStateManager.tsx
+++ b/assets/js/components/AsyncStateManager/AsyncStateManager.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@wordpress/components'
+import { Notice } from 'assets/js/components/Notice/Notice'
 
 const defaultErrorMessage = 'Unknown error occurred.'
 const getErrorMessage = (errors: unknown) => {
@@ -53,12 +53,17 @@ export function AsyncStateManager({
       ) : (
         <div>
           {!!error ? (
-            <div>
-              {getErrorMessage(error)}{' '}
-              <Button variant="link" onClick={retry}>
-                Retry
-              </Button>
-            </div>
+            <Notice level="error">
+              <div className="ntw-flex ntw-justify-between ntw-gap-16px">
+                <div>{getErrorMessage(error)}</div>
+                <button
+                  onClick={retry}
+                  className="ntw-font-bold ntw-uppercase ntw-tracking-wider"
+                >
+                  Retry
+                </button>
+              </div>
+            </Notice>
           ) : (
             children
           )}

--- a/assets/js/components/AsyncStateManager/AsyncStateManager.tsx
+++ b/assets/js/components/AsyncStateManager/AsyncStateManager.tsx
@@ -1,15 +1,48 @@
 import { Button } from '@wordpress/components'
 
+const defaultErrorMessage = 'Unknown error occurred.'
+const getErrorMessage = (errors: unknown) => {
+  // errors are untyped so we need to narrow them down into something we can trust
+  // it's a mouthful, but each of these is required to ensure that we have a Fetch error
+  // that conforms to our Nota Error structure
+  if (
+    errors === null ||
+    typeof errors !== 'object' ||
+    !('data' in errors) ||
+    errors.data === null ||
+    typeof errors.data !== 'object' ||
+    !('data' in errors.data)
+  )
+    return defaultErrorMessage
+
+  // WP encodes errors as such:
+  // { data: { code: string; message: string }[] }
+  // so we want to find any errors that are Nota specific
+  const errorData = errors?.data?.data || []
+  if (!Array.isArray(errorData)) return null
+  const notaError = errorData.find(
+    (error): error is { message: string } =>
+      // this ensures it's a nota_error
+      typeof error === 'object' &&
+      'code' in error &&
+      error.code === 'nota_error' &&
+      // this ensures our nota error has a message
+      'message' in error &&
+      typeof error.message === 'string',
+  )
+  return notaError?.message || defaultErrorMessage
+}
+
 interface Props {
   retry: () => void
   isLoading: boolean
-  hasError: boolean
+  error?: unknown
   children: React.ReactNode
 }
 
 export function AsyncStateManager({
   isLoading,
-  hasError,
+  error,
   retry,
   children,
 }: Props) {
@@ -19,9 +52,9 @@ export function AsyncStateManager({
         'Loading...'
       ) : (
         <div>
-          {hasError ? (
+          {!!error ? (
             <div>
-              There was an error.{' '}
+              {getErrorMessage(error)}{' '}
               <Button variant="link" onClick={retry}>
                 Retry
               </Button>

--- a/assets/js/components/Notice/Notice.tsx
+++ b/assets/js/components/Notice/Notice.tsx
@@ -25,7 +25,7 @@ export function Notice({ level, children }: Props) {
       )}
     >
       <Icon size={24} className="ntw-mr-8px ntw-flex-shrink-0" />
-      <div>{children}</div>
+      <div className="ntw-flex-1">{children}</div>
     </div>
   )
 }

--- a/assets/js/components/PostToolsMetaBox/ScreenResults.tsx
+++ b/assets/js/components/PostToolsMetaBox/ScreenResults.tsx
@@ -94,7 +94,7 @@ export function ScreenResults({ seoData, components, postHTML }: Props) {
                   title="Headlines"
                   subtitle="Select a headline to use on the page"
                   isLoading={seoData.headlines.isLoading}
-                  hasError={seoData.headlines.isError}
+                  error={seoData.headlines.error}
                   options={seoData.headlines.data}
                   onSelect={editPostTitle}
                   updateOptions={seoData.headlines.update}
@@ -112,7 +112,7 @@ export function ScreenResults({ seoData, components, postHTML }: Props) {
                   title="Excerpt"
                   subtitle="Select an excerpt to use on the page"
                   isLoading={seoData.excerpt.isLoading}
-                  hasError={seoData.excerpt.isError}
+                  error={seoData.excerpt.error}
                   options={seoData.excerpt.data}
                   onSelect={editPostExcerpt}
                   updateOptions={seoData.excerpt.update}
@@ -132,7 +132,7 @@ export function ScreenResults({ seoData, components, postHTML }: Props) {
                     subtitle="Select the tags you want to use on this page"
                     history={seoData.tags.history}
                     isLoading={seoData.tags.isLoading}
-                    hasError={seoData.tags.isError}
+                    error={seoData.tags.error}
                     tags={seoData.tags.data}
                     onRefresh={() =>
                       seoData.tags.refresh({
@@ -149,7 +149,7 @@ export function ScreenResults({ seoData, components, postHTML }: Props) {
                   title="Page Title"
                   subtitle="Select a page title to use in your page"
                   isLoading={seoData.metaTitles.isLoading}
-                  hasError={seoData.metaTitles.isError}
+                  error={seoData.metaTitles.error}
                   options={seoData.metaTitles.data}
                   onSelect={editMetaTitle}
                   updateOptions={seoData.metaTitles.update}
@@ -168,7 +168,7 @@ export function ScreenResults({ seoData, components, postHTML }: Props) {
                   title="Meta Description"
                   subtitle="Select a meta description to use in your page"
                   isLoading={seoData.metaDescriptions.isLoading}
-                  hasError={seoData.metaDescriptions.isError}
+                  error={seoData.metaDescriptions.error}
                   options={seoData.metaDescriptions.data}
                   onSelect={editMetaDescription}
                   updateOptions={seoData.metaDescriptions.update}

--- a/assets/js/components/TextOptionList/TextOptionList.tsx
+++ b/assets/js/components/TextOptionList/TextOptionList.tsx
@@ -11,7 +11,7 @@ interface Props {
   title: string
   subtitle: string
   isLoading: boolean
-  hasError: boolean
+  error?: unknown
   disabled?: boolean
   disabledMessage?: string
   history?: History
@@ -26,7 +26,7 @@ export function TextOptionList({
   title,
   subtitle,
   isLoading,
-  hasError,
+  error,
   disabled,
   disabledMessage,
   history,
@@ -48,7 +48,7 @@ export function TextOptionList({
       ) : (
         <AsyncStateManager
           isLoading={isLoading}
-          hasError={hasError}
+          error={error}
           retry={onRefresh}
         >
           <div className="ntw-space-y-16px">


### PR DESCRIPTION
### What does this PR do?
- Updates error display
- Ensures that nota_errors are returned to the API correctly

### Is there any background context you'd like to provide?
Our API already has some errors that it will return in a human readable format. I've updated the WordPress handlers to ensure that those same errors are forwarded onto the client in a format it can use. There's quite a lot of type narrowing going on which we may want to abstract out at some point.

I also tidied up the display of the error component so that it looks presentable.

### What are the relevant tasks?
- TECH-5675

### What gif best represents this PR or how it makes you feel?
![](https://media.giphy.com/media/f0BaErqmljUd2/giphy.gif)
