### PR TITLE
[TECH-5932] Sets initial tab

### DIFF
--- a/assets/js/components/PostToolsMetaBox/PostToolsMetaBox.tsx
+++ b/assets/js/components/PostToolsMetaBox/PostToolsMetaBox.tsx
@@ -61,7 +61,9 @@ const PostToolsMetaBoxInner = () => {
     components,
   })
   const [tabsToRefresh, setTabsToRefresh] = useState<string[]>([])
-  const [currentTab, setCurrentTab] = useState<string>('')
+  const [currentTab, setCurrentTab] = useState<string>(
+    Object.keys(componentMap)[0],
+  )
 
   const componentKeys = Object.keys(components) as (keyof typeof components)[]
   const hasData = componentKeys.some((key) => getPostSeoData[key].data?.length)


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in which selecting "Reanalyze" page on a freshly loaded and already analyzed post appeared not to be working.

### Is there any background context you'd like to provide?

This was due to the tab state not properly being reflected in the code and therefore the refresh option not triggering until the tabs were interacted with.

### What are the relevant tasks?

[TECH-5932](https://app.clickup.com/t/36042459/TECH-5932)

### Does this add any new dependencies? Is there an installation procedure? (bundle, bower, npm, etc.)

### Screenshots (if appropriate)

### What gif best represents this PR or how it makes you feel?
