### PR TITLE
Wordpress deployment scripts

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -4,7 +4,10 @@
 /.wordpress-org
 /.git
 /.github
+/.husky
+/.vscode
 /node_modules
+/scripts
 .distignore
 .gitignore
 .eslintignore
@@ -20,6 +23,7 @@ prettier.config.js
 README.md
 tailwind.config.js
 tsconfig.json
+tsconfig*
 webpack.config.js
 yarn.lock
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,14 @@ on:
   # We'll run this action manually instead of triggering anything.
   workflow_dispatch:
 
+inputs:
+  generate-zip:
+    description: 'Generate package zip file?'
+    default: false
+  dry-run:
+    description: 'Run the deployment process without committing.'
+    default: false
+
 jobs:
   tag:
     name: New tag

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,9 @@ jobs:
           yarn build
       - name: WordPress Plugin Deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
+        with:
+          generate-zip: ${{ inputs.generate-zip }}
+          dry-run: ${{ inputs.dry-run }}
         env:
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,14 +3,13 @@ name: Deploy to WordPress
 on:
   # We'll run this action manually instead of triggering anything.
   workflow_dispatch:
-
-inputs:
-  generate-zip:
-    description: 'Generate package zip file?'
-    default: false
-  dry-run:
-    description: 'Run the deployment process without committing.'
-    default: false
+    inputs:
+      generate-zip:
+        description: 'Generate package zip file?'
+        default: false
+      dry-run:
+        description: 'Run the deployment process without committing.'
+        default: false
 
 jobs:
   tag:

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Before running them you'll need to ensure that the `SVN_USERNAME` and `SVN_PASSW
 ### Deploying a new plugin version
 
 1. Ensure all code has been merged to `main` and that the `main` branch has been tagged with the appropriate version. The tag should match the version specified in the `nota-wordpress-plugin.php` file. This means that `v1.1.1` is invalid, instead use `1.1.1`.
-2. Head over to the Actions tab in GitHub and choose "Deploy to WordPress". Make sure the action is targeting the `main` branch.
+2. Head over to the Actions tab in GitHub and choose "Deploy to WordPress". Dropdown the "Use workflow from" dropdown and select the tag you want to deploy.
 3. Sit back, relax, and enjoy the show.
 
 ### Deploying new assets


### PR DESCRIPTION
### What does this PR do?
- Adds inputs to workflow
- Excludes more build directories

### Is there any background context you'd like to provide?
After giving this a couple of run throughs it quickly became clear that there were a few things missing. Firstly, the base action defines some inputs but these aren't automatically surfaced. Turns out we have to manually pass them through. I've updated the workflows to do that.

In the process of running the dry runs I also discovered that there were a couple of files still sneaking through that we weren't expecting. I've updated the `.distignore` file to exlude those. It's unfortunate that we can't simply "ignore all" and only include what we want though. Maybe making a dry run first is just part of our process.

You can see the output of my latest run [here](https://github.com/nota-3/nota-wordpress-plugin/actions/runs/6320478831/job/17163038583).
